### PR TITLE
FIX: force sidebar

### DIFF
--- a/javascripts/discourse/initializers/force-sidebar.js
+++ b/javascripts/discourse/initializers/force-sidebar.js
@@ -1,0 +1,23 @@
+/* forces sidebar to toggle open when viewing desktop site */
+
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { reopenWidget } from "discourse/widgets/widget";
+
+function sidebarToggle(api) {
+  const applicationController = api.container.lookup("controller:application");
+  /* hamburger icon is not loaded */
+  api.reopenWidget("sidebar-toggle", {
+    html(attrs) {
+      if (this.site.desktopView == true && attrs.showSidebar == false) {
+        applicationController.set("showSidebar", true);
+      }
+    },
+  });
+}
+
+export default {
+  name: "desktop-open-sidebar-always",
+  initialize() {
+    withPluginApi("0.10.1", sidebarToggle);
+  },
+};


### PR DESCRIPTION
Forces sidebar to always open when loading in desktop view, due to the hamburger icon being hidden. This also reopens the sidebar-toggle widget without including the toggle (desktop only), hiding the toggle without css.

Before (repro):
This covers the scenario of switching from one theme while the sidebar is off to this theme without a hamburger icon to unhide the sidebar.
![CleanShot 2023-04-28 at 07 28 34@2x](https://user-images.githubusercontent.com/69276978/235151335-050888a1-f8ce-467f-b62b-466d4be8db6c.png)

After:
![CleanShot 2023-04-28 at 07 49 40@2x](https://user-images.githubusercontent.com/69276978/235152024-bf7f6078-f8ec-4224-981a-63dfba5298e8.png)

* Mobile is unaffected by this change

