### PR TITLE
CSS: Fix spacing for chat tabs panels

### DIFF
--- a/scss/spacing.scss
+++ b/scss/spacing.scss
@@ -36,11 +36,6 @@
   padding: 0;
 }
 
-.chat-tabs__tabpanel {
-  width: 25%;
-  max-width: 50%;
-}
-
 .sidebar-section-link-wrapper .sidebar-section-link-prefix.image img {
   border-radius: calc(var(--d-border-radius) / 2);
 }


### PR DESCRIPTION
This removes width specifications for the chat tabs panel and fixes the width of the members tab, enabling it to show as it is intended.