### PR TITLE
UX: Fixes hover color for PM header icon

### DIFF
--- a/scss/colors.scss
+++ b/scss/colors.scss
@@ -105,6 +105,11 @@
   color: var(--bright-text);
 }
 
+.discourse-no-touch .d-header-icons .btn-flat.btn-hover,
+.discourse-no-touch .d-header-icons .btn-flat:hover .d-icon {
+  color: unset;
+}
+
 .sidebar-section-link-wrapper {
   .sidebar-section-link.active,
   .sidebar-section-link--active {


### PR DESCRIPTION
Avoids this: 

<img width="169" alt="image" src="https://github.com/discourse/discourse-fully/assets/368961/a633ca8a-6d0a-439d-817e-bf7363fb01df">

