### PR TITLE
UX: center content and align header on 404 page

### DIFF
--- a/scss/misc.scss
+++ b/scss/misc.scss
@@ -19,3 +19,17 @@ body.has-sidebar-page.has-full-page-chat #main-outlet-wrapper {
     max-width: unset;
   }
 }
+
+// 404 adjustments
+
+.not-found-container {
+  max-width: var(--d-max-width);
+}
+
+.no-ember {
+  .d-header .wrap > .contents {
+    display: flex;
+    max-width: var(--d-max-width);
+    margin: 0 auto;
+  }
+}


### PR DESCRIPTION
These pages don't have other header elements, so we can simplify the positioning. 

Before:
![image](https://github.com/discourse/discourse-fully/assets/1681963/5734f252-b032-4f23-aabf-3ff8ceba4d8b)


After:
![image](https://github.com/discourse/discourse-fully/assets/1681963/6bc5398e-531e-4f30-98db-fd073bacafce)
