### PR TITLE
DEV: Remove deprecated light-dark toggle component

### DIFF
--- a/about.json
+++ b/about.json
@@ -2,8 +2,7 @@
   "about_url": "https://meta.discourse.org/t/fully-a-full-width-discourse-theme/262833",
   "license_url": null,
   "components": [
-    "https://github.com/discourse/discourse-full-width-component.git",
-    "https://github.com/discourse/discourse-color-scheme-toggle.git"
+    "https://github.com/discourse/discourse-full-width-component.git"
   ],
   "name": "Fully Theme",
   "color_schemes": {


### PR DESCRIPTION
Context: https://meta.discourse.org/t/350991

We've deprecated the light-dark toggle theme component, adding the functionality to core. This PR removes the deprecated theme component from being automatically installed with this theme, since it currently triggers a deprecation notice.

![image](https://github.com/user-attachments/assets/a3e8cd36-6972-42ed-9797-cccf21d2d254)
