### PR TITLE
FIX: forcing unread topic dot to inherit color from parent

### DIFF
--- a/scss/misc.scss
+++ b/scss/misc.scss
@@ -33,3 +33,9 @@ body.has-sidebar-page.has-full-page-chat #main-outlet-wrapper {
     margin: 0 auto;
   }
 }
+
+.sidebar-section-link-wrapper
+  .sidebar-section-link.active
+  .sidebar-section-link-suffix.icon.unread svg {
+    color: inherit;
+}


### PR DESCRIPTION
## Problem

Unread dot can't been seen in the sidebar due to an incorrect active color

## Solution

This change adds css to force the unread indicator svg to inherit the correct color.

## Before 
<img width="573" height="701" alt="image" src="https://github.com/user-attachments/assets/907032ce-4be4-480d-bd9c-e66093b1acb5" />

## After
<img width="576" height="717" alt="image" src="https://github.com/user-attachments/assets/6b1cdafe-2342-4020-951d-1e796b56a893" />
